### PR TITLE
Try to not erase the flash

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,4 +1,8 @@
-
+[alias]
+esp32c2 = "build --release --features esp32c2 --target riscv32imc-unknown-none-elf"
+esp32c3 = "build --release --features esp32c3 --target riscv32imc-unknown-none-elf"
+esp32c6 = "build --release --features esp32c6 --target riscv32imac-unknown-none-elf"
+esp32h2 = "build --release --features esp32h2 --target riscv32imac-unknown-none-elf"
 
 [target.'cfg(any(target_arch = "xtensa", target_arch = "riscv32"))']
 rustflags = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,5 +24,5 @@ debug = false
 debug-assertions = false
 incremental = false
 lto = "fat"
-opt-level = 'z'
+opt-level = "z"
 overflow-checks = false


### PR DESCRIPTION
This makes no sense at all, but it's an interesting experiment: verify flash contents and erase only when needed. Does not speed up probe-rs flashing in a very meaningful manner, but still pretty cool :)

Actually, thinking on this some, double buffering in probe-rs means that erase in this PR now happens in parallel with code download, except for the first block.