### PR TITLE
Fix addressable flash size

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -167,7 +167,7 @@ pub static FlashDevice: FlashDeviceDescription = FlashDeviceDescription {
     dev_name: [0u8; 128],
     dev_type: 5,
     dev_addr: 0x0,
-    device_size: 0x4000000, /* Max of 64MB */
+    device_size: 0x1000000, // Max of 16MB
     // TODO change per variant?
     page_size: 16384,
     _reserved: 0,

--- a/src/main.rs
+++ b/src/main.rs
@@ -168,7 +168,6 @@ pub static FlashDevice: FlashDeviceDescription = FlashDeviceDescription {
     dev_type: 5,
     dev_addr: 0x0,
     device_size: 0x1000000, // Max of 16MB
-    // TODO change per variant?
     page_size: 16384,
     _reserved: 0,
     empty: 0xFF,


### PR DESCRIPTION
C2, C3, C6 and H2 have 16MB addressable flash space as per TRM.