### PR TITLE
Remove decompressor state from the generated binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 /target
-
+/output
 esp32c3.bin

--- a/ld/esp32c2.x
+++ b/ld/esp32c2.x
@@ -1,6 +1,6 @@
 MEMORY {
     /* Start 64k into the RAM region */
-    IRAM : ORIGIN = 0x4038C000, LENGTH = 0x40800
+    IRAM : ORIGIN = 0x4038C000, LENGTH = 0x10800
 }
 
 PROVIDE(esp_rom_spiflash_attach = spi_flash_attach);

--- a/ld/esp32c3.x
+++ b/ld/esp32c3.x
@@ -1,6 +1,6 @@
 MEMORY {
     /* Start 64k into the RAM region */
-    IRAM : ORIGIN = 0x40390000, LENGTH = 0x40000
+    IRAM : ORIGIN = 0x40390000, LENGTH = 0x10000
 }
 
 PROVIDE( esp_rom_spiflash_wait_idle = 0x4000010c );

--- a/ld/esp32c6.x
+++ b/ld/esp32c6.x
@@ -1,7 +1,7 @@
 
 MEMORY {
     /* Start 64k into the RAM region */
-    IRAM : ORIGIN = 0x40810000, LENGTH = 0x40000
+    IRAM : ORIGIN = 0x40810000, LENGTH = 0x10000
 }
 
 PROVIDE(esp_rom_spiflash_attach = spi_flash_attach);

--- a/ld/esp32h2.x
+++ b/ld/esp32h2.x
@@ -1,6 +1,6 @@
 MEMORY {
     /* Start 64k into the RAM region */
-    IRAM : ORIGIN = 0x40810000, LENGTH = 0x40000
+    IRAM : ORIGIN = 0x40810000, LENGTH = 0x10000
 }
 
 PROVIDE ( esp_rom_spiflash_attach = spi_flash_attach );

--- a/ld/esp32s2.x
+++ b/ld/esp32s2.x
@@ -1,6 +1,6 @@
 MEMORY {
     /* SRAM1 + 0x4000 cache + 0x400 vectors */
-    IRAM : ORIGIN = 0x4002C400, LENGTH = 0x48000 - 0x4000 - 0x400
+    IRAM : ORIGIN = 0x4002C400, LENGTH = 0x10000
 }
 
 /**

--- a/ld/esp32s3.x
+++ b/ld/esp32s3.x
@@ -1,6 +1,6 @@
 MEMORY {
     /* SRAM2 + 0x8400 */
-    IRAM : ORIGIN = 0x40380400, LENGTH = 0x40000
+    IRAM : ORIGIN = 0x40380400, LENGTH = 0x10000
 }
 
 /* ROM function interface esp32s3.rom.ld for esp32s3

--- a/src/api_xtensa.rs
+++ b/src/api_xtensa.rs
@@ -12,7 +12,7 @@ static STACK_PTR: u32 = 0x3FFE_0000;
 #[cfg(feature = "esp32s2")]
 #[no_mangle]
 // End of SRAM1. SRAM0 may be used as cache and thus may be inaccessible.
-static STACK_PTR: u32 = 0x4000_0000;
+static STACK_PTR: u32 = 0x3FFD_F000;
 
 #[cfg(feature = "esp32s3")]
 #[no_mangle]

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,7 @@ const _: [u8; 43776] = [0; core::mem::size_of::<Decompressor>()];
 //  - stack comes automatically after the loader
 
 // Xtensa   | Image IRAM  | Image DRAM  | STATE_ADDR  | data_load_addr | Stack (top)
-// ESP32-S2 | 0x4002_C400 | 0x3FFB_C400 | 0x3FFE_0000 | 0x3FFF_0000    | 0x4000_0000
+// ESP32-S2 | 0x4002_C400 | 0x3FFB_C400 | 0x3FFB_E000 | 0x3FFC_E000    | 0x3FFD_F000
 // ESP32-S3 | 0x4038_0400 | 0x3FC9_0400 | 0x3FCB_0000 | 0x3FCC_0000    | 0x3FCD_0000
 
 // RISC-V   | Image IRAM  | Image DRAM  | STATE_ADDR  | data_load_addr | DRAM end (avoiding cache)
@@ -32,17 +32,17 @@ const _: [u8; 43776] = [0; core::mem::size_of::<Decompressor>()];
 
 // "State" base address
 #[cfg(feature = "esp32s2")]
-const STATE_ADDR: usize = 0x3FFE_0000;
+const STATE_ADDR: usize = 0x3FFB_E000;
 #[cfg(feature = "esp32s3")]
 const STATE_ADDR: usize = 0x3FCB_0000;
 #[cfg(feature = "esp32c2")]
 const STATE_ADDR: usize = 0x3FCB_0000;
 #[cfg(feature = "esp32c3")]
-const STATE_ADDR: usize = 0x3FCC_0000;
+const STATE_ADDR: usize = 0x3FCB_0000;
 #[cfg(feature = "esp32c6")]
 const STATE_ADDR: usize = 0x4086_0000;
 #[cfg(feature = "esp32h2")]
-const STATE_ADDR: usize = 0x4083_0000;
+const STATE_ADDR: usize = 0x4082_0000;
 
 // End of target memory configuration
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -119,20 +119,13 @@ const DECOMPRESSOR: *mut Decompressor = (STATE_ADDR + 4) as *mut Decompressor;
 
 /// Setup the device for the flashing process.
 #[no_mangle]
-pub unsafe extern "C" fn Init_impl(_adr: u32, _clk: u32, fnc: u32) -> i32 {
-    const FUNC_ERASE: u32 = 1;
-    if fnc == FUNC_ERASE {
-        *INITED = false;
-    }
+pub unsafe extern "C" fn Init_impl(_adr: u32, _clk: u32, _fnc: u32) -> i32 {
+    dprintln!("INIT");
 
-    if *INITED {
-        dprintln!("INIT");
+    flash::attach();
 
-        flash::attach();
-
-        *DECOMPRESSOR = Decompressor::new();
-        *INITED = true;
-    }
+    *DECOMPRESSOR = Decompressor::new();
+    *INITED = true;
 
     0
 }
@@ -177,7 +170,11 @@ pub unsafe extern "C" fn UnInit_impl(_fnc: u32) -> i32 {
     (*DECOMPRESSOR).flush();
 
     // The flash ROM functions don't wait for the end of the last operation.
-    flash::wait_for_idle()
+    let r = flash::wait_for_idle();
+
+    *INITED = false;
+
+    r
 }
 
 pub struct Decompressor {

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,13 +5,52 @@
     feature(asm_experimental_arch, naked_functions)
 )]
 
+// Target memory configuration
+
+// Decompressor is 43776 bytes, reserve more to hold INIT (reserve 64K)
+const _: [u8; 43776] = [0; core::mem::size_of::<Decompressor>()];
+
+// Placement:
+// - Xtensa: Pin stack top first, calculate backwards:
+//  - 32K stack
+//  - 32K for data pages
+//  - 64K for state (decompressor + INIT)
+// - RISC-V: At the end of memory, calculate backwards:
+//  - 64K for data pages (32K needed, but 64K is easier to calculate)
+//  - 64K for state (decompressor + INIT)
+//  - stack comes automatically after the loader
+
+// Xtensa   | Image IRAM  | Image DRAM  | STATE_ADDR  | data_load_addr | Stack (top)
+// ESP32-S2 | 0x4002_C400 | 0x3FFB_C400 | 0x3FFE_0000 | 0x3FFF_0000    | 0x4000_0000
+// ESP32-S3 | 0x4038_0400 | 0x3FC9_0400 | 0x3FCB_0000 | 0x3FCC_0000    | 0x3FCD_0000
+
+// RISC-V   | Image IRAM  | Image DRAM  | STATE_ADDR  | data_load_addr | DRAM end (avoiding cache)
+// ESP32-C2 | 0x4038_C000 | 0x3FCA_C000 | 0x3FCB_0000 | 0x3FCC_0000    | 0x3FCD_0000
+// ESP32-C3 | 0x4039_0000 | 0x3FC1_0000 | 0x3FCB_0000 | 0x3FCC_0000    | 0x3FCD_0000
+// ESP32-C6 | 0x4081_0000 | 0x4081_0000 | 0x4084_0000 | 0x4085_0000    | 0x4086_0000
+// ESP32-H2 | 0x4081_0000 | 0x4081_0000 | 0x4082_0000 | 0x4083_0000    | 0x4083_8000 !! has smaller RAM, only reserve 32K for data
+
+// "State" base address
+#[cfg(feature = "esp32s2")]
+const STATE_ADDR: usize = 0x3FFE_0000;
+#[cfg(feature = "esp32s3")]
+const STATE_ADDR: usize = 0x3FCB_0000;
+#[cfg(feature = "esp32c2")]
+const STATE_ADDR: usize = 0x3FCB_0000;
+#[cfg(feature = "esp32c3")]
+const STATE_ADDR: usize = 0x3FCC_0000;
+#[cfg(feature = "esp32c6")]
+const STATE_ADDR: usize = 0x4086_0000;
+#[cfg(feature = "esp32h2")]
+const STATE_ADDR: usize = 0x4083_0000;
+
+// End of target memory configuration
+
 // Define necessary functions for flash loader
 //
 // These are taken from the [ARM CMSIS-Pack documentation]
 //
 // [ARM CMSIS-Pack documentation]: https://arm-software.github.io/CMSIS_5/Pack/html/algorithmFunc.html
-
-use core::ptr::addr_of_mut;
 
 use panic_never as _;
 
@@ -25,12 +64,12 @@ mod flash;
 mod properties;
 mod tinfl;
 
+#[cfg(not(any(target_arch = "xtensa", target_arch = "riscv32")))]
+compile_error!("specify the target with `--target`");
+
 const ERROR_BASE_INTERNAL: i32 = -1000;
 const ERROR_BASE_TINFL: i32 = -2000;
 const ERROR_BASE_FLASH: i32 = -4000;
-
-#[cfg(not(any(target_arch = "xtensa", target_arch = "riscv32")))]
-compile_error!("specify the target with `--target`");
 
 #[cfg(feature = "log")]
 mod log {
@@ -75,62 +114,24 @@ macro_rules! dprintln {
     ($fmt:expr, $($arg:tt)*) => {};
 }
 
-static mut DECOMPRESSOR: Option<Decompressor> = None;
-
-#[cfg(feature = "esp32s2")]
-mod chip_specific {
-    use core::ops::Range;
-
-    pub const OFFSET: isize = 0x4002_8000 - 0x3FFB_8000;
-    pub const IRAM: Range<usize> = 0x4000_0000..0x4007_2000;
-}
-
-#[cfg(feature = "esp32s3")]
-mod chip_specific {
-    use core::ops::Range;
-
-    pub const OFFSET: isize = 0x4037_8000 - 0x3FC8_8000;
-    pub const IRAM: Range<usize> = 0x4000_0000..0x403E_0000;
-}
-
-// We need to access the page buffers and decompressor on the data bus, otherwise we'll run into
-// LoadStoreError exceptions. This should be removed once probe-rs can place data into the correct
-// memory region.
-fn addr_to_data_bus(addr: usize) -> usize {
-    #[cfg(any(feature = "esp32s2", feature = "esp32s3"))]
-    {
-        if chip_specific::IRAM.contains(&addr) {
-            return (addr as isize - chip_specific::OFFSET) as usize;
-        }
-    }
-
-    addr
-}
-
-unsafe fn data_bus<T>(ptr: *const T) -> *const T {
-    addr_to_data_bus(ptr as usize) as *const T
-}
-
-unsafe fn data_bus_mut<T>(ptr: *mut T) -> *mut T {
-    addr_to_data_bus(ptr as usize) as *mut T
-}
-
-unsafe fn decompressor<'a>() -> Option<&'a mut Decompressor> {
-    let decompressor = addr_of_mut!(DECOMPRESSOR);
-    let decompressor = data_bus_mut(decompressor);
-
-    decompressor.as_mut().unwrap_unchecked().as_mut()
-}
+const INITED: *mut bool = STATE_ADDR as *mut bool;
+const DECOMPRESSOR: *mut Decompressor = (STATE_ADDR + 4) as *mut Decompressor;
 
 /// Setup the device for the flashing process.
 #[no_mangle]
-pub unsafe extern "C" fn Init_impl(_adr: u32, _clk: u32, _fnc: u32) -> i32 {
-    if decompressor().is_none() {
+pub unsafe extern "C" fn Init_impl(_adr: u32, _clk: u32, fnc: u32) -> i32 {
+    const FUNC_ERASE: u32 = 1;
+    if fnc == FUNC_ERASE {
+        *INITED = false;
+    }
+
+    if *INITED {
         dprintln!("INIT");
 
         flash::attach();
 
-        DECOMPRESSOR = Some(Decompressor::new());
+        *DECOMPRESSOR = Decompressor::new();
+        *INITED = true;
     }
 
     0
@@ -151,7 +152,7 @@ pub unsafe extern "C" fn EraseChip_impl() -> i32 {
 
 #[no_mangle]
 pub unsafe extern "C" fn ProgramPage_impl(adr: u32, sz: u32, buf: *const u8) -> i32 {
-    let Some(decompressor) = decompressor() else {
+    if !*INITED {
         return ERROR_BASE_INTERNAL - 1;
     };
 
@@ -162,21 +163,18 @@ pub unsafe extern "C" fn ProgramPage_impl(adr: u32, sz: u32, buf: *const u8) -> 
 
     dprintln!("PROGRAM {} bytes @ {}", sz, adr);
 
-    // Access data through the data bus
-    let buf = data_bus(buf);
-
     let input = core::slice::from_raw_parts(buf, sz as usize);
 
-    decompressor.program(adr, input)
+    (*DECOMPRESSOR).program(adr, input)
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn UnInit_impl(_fnc: u32) -> i32 {
-    let Some(decompressor) = decompressor() else {
+    if !*INITED {
         return ERROR_BASE_INTERNAL - 1;
     };
 
-    decompressor.flush();
+    (*DECOMPRESSOR).flush();
 
     // The flash ROM functions don't wait for the end of the last operation.
     flash::wait_for_idle()


### PR DESCRIPTION
Companion PR that defines `data_load_address`: https://github.com/probe-rs/probe-rs/pull/2099