### PR TITLE
Verify

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,9 +18,9 @@ checksum = "b0dc75d1f6543e7468fe83fe67257da512d7f1d2d5b66adfbbcf86b22df8d370"
 
 [[package]]
 name = "proc-macro-hack"
-version = "0.5.19"
+version = "0.5.20+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
+checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
@@ -53,9 +53,9 @@ dependencies = [
 
 [[package]]
 name = "ufmt"
-version = "0.1.0"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e7ecea7ef79d3f8f878eee614afdf5256475c63ad76139d4da6125617c784a0"
+checksum = "31d3c0c63312dfc9d8e5c71114d617018a19f6058674003c0da29ee8d8036cdd"
 dependencies = [
  "proc-macro-hack",
  "ufmt-macros",
@@ -64,9 +64,9 @@ dependencies = [
 
 [[package]]
 name = "ufmt-macros"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed813e34a2bfa9dc58ee2ed8c8314d25e6d70c911486d64b8085cb695cfac069"
+checksum = "e4ab6c92f30c996394a8bd525aef9f03ce01d0d7ac82d81902968057e37dd7d9"
 dependencies = [
  "proc-macro-hack",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-panic-never  = "0.1.0"
+panic-never = "0.1.0"
 ufmt = { version = "0.1.0", optional = true }
 
 

--- a/ld/esp32.x
+++ b/ld/esp32.x
@@ -2,6 +2,7 @@ MEMORY {
     /* Middle of SRAM0 */
     IRAM : ORIGIN = 0x40090000, LENGTH = 0x10000
 }
+
 /*
 ESP32 ROM address table
 Generated for ROM with MD5sum:

--- a/src/api.rs
+++ b/src/api.rs
@@ -23,6 +23,11 @@ pub unsafe extern "C" fn ProgramPage(adr: u32, sz: u32, buf: *const u8) -> i32 {
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn Verify(adr: u32, sz: u32, buf: *const u8) -> i32 {
+    crate::Verify_impl(adr, sz, buf)
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn ReadFlash(adr: u32, sz: u32, buf: *mut u8) -> i32 {
     crate::ReadFlash_impl(adr, sz, buf)
 }

--- a/src/api_xtensa.rs
+++ b/src/api_xtensa.rs
@@ -88,6 +88,23 @@ pub unsafe extern "C" fn ProgramPage(adr: u32, sz: u32, buf: *const u8) -> i32 {
 
 #[no_mangle]
 #[naked]
+pub unsafe extern "C" fn Verify(adr: u32, sz: u32, buf: *const u8) -> i32 {
+    asm!(
+        "
+        .global Verify_impl
+        l32r a1, STACK_PTR
+        mov.n a6, a2
+        mov.n a7, a3
+        mov.n a8, a4
+        call4 Verify_impl
+        mov.n a2, a6
+        ",
+        options(noreturn)
+    )
+}
+
+#[no_mangle]
+#[naked]
 pub unsafe extern "C" fn ReadFlash(adr: u32, sz: u32, buf: *mut u8) -> i32 {
     asm!(
         "

--- a/src/main.rs
+++ b/src/main.rs
@@ -221,17 +221,8 @@ pub unsafe extern "C" fn UnInit_impl(fnc: u32) -> i32 {
     *INITED = 0;
 
     if fnc == 2 {
-        // program
-        (*DECOMPRESSOR).flush(write_to_flash);
-
         // The flash ROM functions don't wait for the end of the last operation.
-        let r = flash::wait_for_idle();
-
-        r
-    } else if fnc == 3 {
-        // verify
-        // FIXME: a bit wonky, we don't really want to report verification failures in UnInit
-        (*DECOMPRESSOR).flush(verify_flash)
+        flash::wait_for_idle()
     } else {
         0
     }
@@ -327,12 +318,6 @@ impl Decompressor {
         process: fn(u32, &[u8]) -> i32,
     ) -> i32 {
         if self.image_start != address {
-            // Finish previous image
-            let status = self.flush(process);
-            if status < 0 {
-                return status;
-            }
-
             if data.len() < 4 {
                 // We don't have enough bytes to read the length
                 return ERROR_BASE_INTERNAL - 4;


### PR DESCRIPTION
Companion PR of https://github.com/probe-rs/probe-rs/pull/2722 aimed to provide a faster verify operation.

Rustc is a huge dummy when it comes to Verify: doing any sort of normal array operation immediately bloats up the loader by ~30kB - by adding all the compiler builtins that we don't use. Hence the heap of unsafe code.