### PR TITLE
Fix S31 efuse block sizes

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -31,6 +31,7 @@ $deviceMap = @{
     "esp32c61" = "riscv32imac-unknown-none-elf"
     "esp32h2" = "riscv32imac-unknown-none-elf"
     "esp32p4" = "riscv32imafc-unknown-none-elf"
+    "esp32s31" = "riscv32imafc-unknown-none-elf"
 }
 
 # Validate device (if specified) and build list

--- a/src/chip/esp32s31.rs
+++ b/src/chip/esp32s31.rs
@@ -25,7 +25,7 @@ pub const ROM_TABLE_ENTRY_SIZE: u32 = 12;
 pub const EFUSE_INFO: EfuseInfo = EfuseInfo {
     // EFUSE peripheral base = 0x20715000; readable data starts at offset 0x2C
     block0: 0x2071_5000 + 0x2C,
-    block_sizes: &[6, 6, 8, 8, 8, 8, 8, 8, 8, 8, 8],
+    block_sizes: &[9, 6, 8, 8, 8, 8, 8, 8, 8, 8],
 };
 
 pub const MEM_SPI: MemSpi = MemSpi {


### PR DESCRIPTION
Based on https://github.com/espressif/esptool/blob/master/espefuse/efuse/esp32s31/mem_definition.py#L101-L112

- BLOCK0 is 9 words
- There is no BLOCK10